### PR TITLE
Add web API, SVG rendering, and CI; refactor layout engine

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+__pycache__/
+*.pyc
+build/
+dist/
+*.spec
+tests/
+.venv/
+venv/
+.pytest_cache/
+*.egg-info/
+.DS_Store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,20 @@ jobs:
 
   build-executable:
     needs: test
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact: radiant-heat-linux-x86_64
+            binary: dist/radiant-heat
+          - os: windows-latest
+            artifact: radiant-heat-windows-x86_64
+            binary: dist/radiant-heat.exe
+          - os: macos-latest
+            artifact: radiant-heat-macos-arm64
+            binary: dist/radiant-heat
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -57,12 +70,66 @@ jobs:
           python-version: "3.11"
           cache: pip
 
+      # Build directly with PyInstaller so the same step works on every OS
+      # (the build_executable.sh helper is bash-only). PyInstaller names the
+      # output radiant-heat.exe automatically on Windows.
+      - name: Install build dependencies
+        run: pip install pyinstaller numpy flask
+
       - name: Build standalone executable
-        run: ./build_executable.sh
+        run: pyinstaller --clean --noconfirm radiant-heat.spec
+
+      - name: Smoke test executable
+        run: ${{ matrix.binary }} compute --length 10 --width 10 --spacing 1
 
       - name: Upload executable artifact
         uses: actions/upload-artifact@v4
         with:
-          name: radiant-heat-linux-x86_64
-          path: dist/radiant-heat
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.binary }}
           if-no-files-found: error
+
+  docker:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t radiant-heat:ci .
+
+      - name: Smoke test image (CLI)
+        run: docker run --rm radiant-heat:ci compute --length 10 --width 10 --spacing 1
+
+      - name: Smoke test image (API)
+        run: |
+          docker run -d --name rh -p 8000:8000 radiant-heat:ci
+          for i in $(seq 1 15); do
+            if curl -sf http://127.0.0.1:8000/health; then ok=1; break; fi
+            sleep 1
+          done
+          docker logs rh
+          docker rm -f rh
+          test "$ok" = "1"
+
+      # Publish to GitHub Container Registry on pushes to the default branch so
+      # the image can be pulled with `docker pull ghcr.io/<owner>/<repo>`.
+      - name: Log in to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push image to GHCR
+        if: github.event_name == 'push'
+        run: |
+          image="ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
+          docker tag radiant-heat:ci "$image:latest"
+          docker tag radiant-heat:ci "$image:${{ github.sha }}"
+          docker push "$image:latest"
+          docker push "$image:${{ github.sha }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,25 @@ jobs:
           name: coverage-${{ matrix.python-version }}
           path: coverage.xml
           if-no-files-found: ignore
+
+  build-executable:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Build standalone executable
+        run: ./build_executable.sh
+
+      - name: Upload executable artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: radiant-heat-linux-x86_64
+          path: dist/radiant-heat
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    env:
+      # Use a non-interactive matplotlib backend so headless imports never
+      # try to open a display.
+      MPLBACKEND: Agg
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests with coverage
+        run: |
+          pytest tests/ -v --cov=src --cov-report=term-missing --cov-report=xml
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.python-version }}
+          path: coverage.xml
+          if-no-files-found: ignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# Containerized radiant heating layout service.
+#
+# Build:  docker build -t radiant-heat .
+# Serve:  docker run --rm -p 8000:8000 radiant-heat
+#         -> open http://localhost:8000  (UI) or call /api/layout (services)
+# CLI:    docker run --rm radiant-heat compute --length 10 --width 10 --spacing 1
+#         docker run --rm radiant-heat svg --length 10 --width 10 -o - > layout.svg
+#
+# Runs identically on Windows, macOS and Linux via Docker Desktop, which avoids
+# the platform-specific native-binary problem of a PyInstaller build.
+FROM python:3.12-slim AS base
+
+# Don't write .pyc files; flush stdout/stderr immediately for container logs.
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PORT=8000
+
+WORKDIR /app
+
+# Install dependencies/package first so layers cache well.
+COPY pyproject.toml README.md ./
+COPY src/ ./src/
+RUN pip install --no-cache-dir .
+
+# Run as a non-root user.
+RUN useradd --create-home --uid 10001 appuser
+USER appuser
+
+EXPOSE 8000
+
+# Liveness check against the API's /health endpoint (no curl in slim image).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD python -c "import os,urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:%s/health' % os.environ.get('PORT','8000'), timeout=3).status==200 else 1)"
+
+# `radiant-heat` is the unified CLI. Default to serving the HTTP API; override
+# the command (e.g. `compute ...`) to use the one-shot subcommands instead.
+ENTRYPOINT ["radiant-heat"]
+CMD ["serve", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,27 +1,35 @@
 # Radiant Heating Layout Generator
 
-This Python script generates and visualizes radiant heating pipe layouts for rooms. It creates an efficient serpentine pattern that ensures even heat distribution while minimizing pipe length.
+[![CI](https://github.com/aazad01/RadiantHeatingMapper/actions/workflows/ci.yml/badge.svg)](https://github.com/aazad01/RadiantHeatingMapper/actions/workflows/ci.yml)
+
+This project generates and visualizes radiant heating pipe layouts for rooms. It creates an efficient serpentine pattern that ensures even heat distribution while minimizing pipe length, and exposes the layout engine three ways: a structured Python API, a command-line visualizer, and an HTTP service other applications can call.
 
 ## Features
 
-- Interactive visualization of pipe installation
-- Automatic calculation of total pipe length
-- Support for any room size
-- Animated installation process for rooms under 600m²
-- Static layout display for larger rooms
-- Coverage statistics and grid information
+- Serpentine pipe-path planning with total pipe length and coverage statistics
+- Structured `compute_layout()` function returning JSON-serializable results
+- **HTTP API** (Flask) so other services can request layouts over the network
+- Dependency-free SVG rendering of layouts (no display backend required)
+- Interactive matplotlib visualization with animated installation (rooms < 600m²) or static layout (larger rooms)
+- Browser UI for quick experimentation
+- Continuous integration running the test suite across Python 3.9–3.12
 
 ## Project Structure
 
 ```
-RadiantHeating/
+RadiantHeatingMapper/
 ├── src/
-│   └── radiantheat.py      # Core implementation
+│   ├── radiantheat.py        # Core geometry + matplotlib CLI visualizer
+│   ├── render.py             # Dependency-free SVG renderer
+│   └── api.py                # Flask HTTP API + browser UI
 ├── tests/
-│   ├── test_radiantheat.py # Unit tests
+│   ├── test_radiantheat.py   # Geometry unit tests
+│   ├── test_compute_layout.py# compute_layout()/SVG tests
+│   ├── test_api.py           # HTTP API tests
 │   └── test_coordinates.json # Test data
-├── requirements.txt        # Dependencies
-└── README.md              # Documentation
+├── .github/workflows/ci.yml  # CI pipeline
+├── requirements.txt          # Dependencies
+└── README.md                 # Documentation
 ```
 
 ## Installation
@@ -34,7 +42,8 @@ pip install -r requirements.txt
 
 ## Usage
 
-Run the script:
+### Command-line visualizer
+
 ```bash
 python src/radiantheat.py
 ```
@@ -43,6 +52,55 @@ You will be prompted to enter:
 - Room length (in meters)
 - Room width (in meters)
 - Pipe spacing (in meters, typically 0.2)
+
+### Python library
+
+```python
+from radiantheat import compute_layout
+
+layout = compute_layout(room_length=10, room_width=10, pipe_spacing=1.0)
+print(layout["pipe_length_m"])          # 71.0
+print(layout["coverage"]["coverage_percent"])  # 64.0
+print(layout["coordinates"][:3])        # [[1.0, 1.0], [1.0, 2.0], [1.0, 3.0]]
+```
+
+### Web API
+
+Start the service:
+
+```bash
+python src/api.py                       # http://127.0.0.1:8000
+# or, for production:
+pip install gunicorn
+gunicorn --chdir src 'api:create_app()'
+```
+
+Open `http://127.0.0.1:8000/` for the browser UI, or call the API from another service:
+
+| Method & path        | Description                                  |
+| -------------------- | -------------------------------------------- |
+| `GET /health`        | Health/readiness probe                       |
+| `GET /api/layout`    | Compute a layout from query parameters       |
+| `POST /api/layout`   | Compute a layout from a JSON body            |
+| `GET /api/layout.svg`| Render a layout as an SVG image              |
+| `GET /openapi.json`  | Machine-readable OpenAPI 3.0 description      |
+
+```bash
+# Query parameters
+curl "http://127.0.0.1:8000/api/layout?room_length=10&room_width=10&pipe_spacing=1"
+
+# JSON body
+curl -X POST http://127.0.0.1:8000/api/layout \
+  -H 'Content-Type: application/json' \
+  -d '{"room_length": 10, "room_width": 10, "pipe_spacing": 1}'
+
+# SVG image
+curl "http://127.0.0.1:8000/api/layout.svg?room_length=10&room_width=10&pipe_spacing=1" -o layout.svg
+```
+
+`pipe_spacing` is optional and defaults to `0.2`. The API returns `400` for
+missing/invalid parameters and `422` when the room is too small for the
+requested spacing.
 
 ### Example Output
 
@@ -90,10 +148,13 @@ The script provides two types of visualizations:
 
 ## Testing
 
-Run the unit tests:
+Run the full test suite from the repository root:
 ```bash
-python -m pytest tests/test_radiantheat.py -v
+python -m pytest tests/ -v
 ```
+
+CI runs the same suite (with coverage) on every push and pull request across
+Python 3.9–3.12 via `.github/workflows/ci.yml`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,34 @@ print(layout["coverage"]["coverage_percent"])  # 64.0
 print(layout["coordinates"][:3])        # [[1.0, 1.0], [1.0, 2.0], [1.0, 3.0]]
 ```
 
+### Standalone executable
+
+Build a self-contained binary (no Python install required to run it):
+
+```bash
+./build_executable.sh        # produces dist/radiant-heat
+```
+
+The executable exposes the same engine via subcommands:
+
+```bash
+./dist/radiant-heat compute --length 10 --width 10 --spacing 1   # print JSON layout
+./dist/radiant-heat svg --length 10 --width 10 -o layout.svg     # write an SVG file
+./dist/radiant-heat serve --port 8000                            # run the HTTP API
+```
+
+CI also builds the Linux binary on every run and publishes it as the
+`radiant-heat-linux-x86_64` artifact. The bundled binary excludes matplotlib to
+stay small; the interactive `show` command works from a source checkout with
+`pip install -e '.[viz]'`.
+
+If you prefer a pip-installed command instead of a frozen binary:
+
+```bash
+pip install -e .
+radiant-heat compute --length 10 --width 10 --spacing 1
+```
+
 ### Web API
 
 Start the service:

--- a/README.md
+++ b/README.md
@@ -80,16 +80,48 @@ The executable exposes the same engine via subcommands:
 ./dist/radiant-heat serve --port 8000                            # run the HTTP API
 ```
 
-CI also builds the Linux binary on every run and publishes it as the
-`radiant-heat-linux-x86_64` artifact. The bundled binary excludes matplotlib to
-stay small; the interactive `show` command works from a source checkout with
-`pip install -e '.[viz]'`.
+PyInstaller binaries are **platform-specific** — a Linux build will not run on
+Windows or macOS. CI therefore builds a native binary for each OS on every run
+and publishes them as downloadable artifacts:
+
+| OS | Artifact | File |
+| -- | -------- | ---- |
+| Windows | `radiant-heat-windows-x86_64` | `radiant-heat.exe` |
+| macOS (Apple Silicon) | `radiant-heat-macos-arm64` | `radiant-heat` |
+| Linux | `radiant-heat-linux-x86_64` | `radiant-heat` |
+
+Download the one matching your OS from the workflow run's **Artifacts** section.
+The bundled binary excludes matplotlib to stay small; the interactive `show`
+command works from a source checkout with `pip install -e '.[viz]'`.
 
 If you prefer a pip-installed command instead of a frozen binary:
 
 ```bash
 pip install -e .
 radiant-heat compute --length 10 --width 10 --spacing 1
+```
+
+### Docker
+
+The most portable option — runs identically on Windows, macOS and Linux with
+Docker Desktop, with no platform-specific binary to worry about:
+
+```bash
+docker build -t radiant-heat .
+
+# Serve the API/UI on http://localhost:8000
+docker run --rm -p 8000:8000 radiant-heat
+
+# Or run the CLI directly
+docker run --rm radiant-heat compute --length 10 --width 10 --spacing 1
+```
+
+On pushes to the default branch, CI also publishes the image to GitHub
+Container Registry, so you can skip the build and pull it directly:
+
+```bash
+docker pull ghcr.io/aazad01/radiantheatingmapper:latest
+docker run --rm -p 8000:8000 ghcr.io/aazad01/radiantheatingmapper:latest
 ```
 
 ### Web API

--- a/build_executable.sh
+++ b/build_executable.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Build the standalone "radiant-heat" executable with PyInstaller.
+#
+# Usage:
+#   ./build_executable.sh
+#
+# The resulting binary is written to dist/radiant-heat and is fully
+# self-contained (no Python installation required to run it).
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+python -m pip install --upgrade pip >/dev/null 2>&1 || true
+python -m pip install pyinstaller numpy flask >/dev/null
+
+rm -rf build dist
+pyinstaller --clean --noconfirm radiant-heat.spec
+
+echo
+echo "Built: $(pwd)/dist/radiant-heat"
+./dist/radiant-heat --help >/dev/null && echo "Smoke test (--help) passed."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "radiant-heat-mapper"
+version = "1.0.0"
+description = "Generate, visualize and serve radiant heating pipe layouts."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "MIT" }
+dependencies = [
+    "numpy>=1.24.0,<3.0.0",
+    "flask>=3.0.0,<4.0.0",
+]
+
+[project.optional-dependencies]
+viz = ["matplotlib>=3.7.0,<4.0.0"]
+dev = ["pytest>=7.4.0", "pytest-cov>=4.1.0", "pyinstaller>=6.0.0"]
+
+[project.scripts]
+radiant-heat = "cli:main"
+
+[tool.setuptools]
+package-dir = { "" = "src" }
+py-modules = ["cli", "api", "render", "radiantheat"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/radiant-heat.spec
+++ b/radiant-heat.spec
@@ -33,7 +33,7 @@ exe = EXE(
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
-    upx=True,
+    upx=False,
     runtime_tmpdir=None,
     console=True,
 )

--- a/radiant-heat.spec
+++ b/radiant-heat.spec
@@ -1,0 +1,39 @@
+# PyInstaller spec for the radiant-heat standalone executable.
+# Build with:  pyinstaller radiant-heat.spec   (or ./build_executable.sh)
+#
+# matplotlib is intentionally excluded to keep the binary small and the build
+# fast: the bundled executable targets the headless "compute"/"svg"/"serve"
+# workflows. The interactive "show" command still works when run from a source
+# checkout with matplotlib installed.
+
+block_cipher = None
+
+a = Analysis(
+    ['src/cli.py'],
+    pathex=['src'],
+    binaries=[],
+    datas=[],
+    hiddenimports=['flask', 'numpy'],
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=['matplotlib', 'tkinter', 'PyQt5', 'PySide2', 'PIL', 'cryptography'],
+    cipher=block_cipher,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name='radiant-heat',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    runtime_tmpdir=None,
+    console=True,
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,14 @@
 # Core dependencies
-numpy>=1.24.0,<2.0.0  # For numerical operations and calculations
-matplotlib>=3.7.0,<4.0.0  # For plotting and animations
+numpy>=1.24.0,<3.0.0  # For numerical operations and calculations
+matplotlib>=3.7.0,<4.0.0  # For the interactive CLI visualization
+
+# Web API
+flask>=3.0.0,<4.0.0  # HTTP interface for other services / the browser UI
 
 # Testing dependencies
-pytest>=7.4.0,<8.0.0  # Alternative test runner (more features than unittest)
-pytest-cov>=4.1.0,<5.0.0  # For test coverage reporting
+pytest>=7.4.0  # Test runner
+pytest-cov>=4.1.0  # Test coverage reporting
 
-# Note: unittest and json are part of Python's standard library 
+# Note: unittest and json are part of Python's standard library
+# Optional: install gunicorn to serve the API in production
+#   pip install gunicorn && gunicorn --chdir src 'api:create_app()'

--- a/src/api.py
+++ b/src/api.py
@@ -1,0 +1,285 @@
+"""HTTP API for the radiant heating layout generator.
+
+A small Flask application that exposes the layout engine so other services
+(and a built-in browser UI) can request pipe layouts over HTTP.
+
+Endpoints:
+    GET  /                 Interactive HTML UI.
+    GET  /health           Liveness/readiness probe.
+    GET  /openapi.json     Machine-readable OpenAPI 3.0 description.
+    GET  /api/layout       Compute a layout from query parameters.
+    POST /api/layout       Compute a layout from a JSON body.
+    GET  /api/layout.svg   Render a layout as an SVG image.
+
+Run locally:
+    python src/api.py            # http://127.0.0.1:8000
+    gunicorn 'api:create_app()'  # production WSGI server
+"""
+
+import os
+import sys
+from pathlib import Path
+
+from flask import Flask, jsonify, request, Response
+
+# Allow running as a script (``python src/api.py``) as well as a module.
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from radiantheat import compute_layout, LayoutError  # noqa: E402
+from render import render_svg  # noqa: E402
+
+DEFAULT_SPACING = 0.2
+
+
+def _parse_params(source):
+    """Extract and coerce layout parameters from a dict-like source.
+
+    Returns a tuple ``(room_length, room_width, pipe_spacing)``.
+    Raises ``ValueError`` (with a friendly message) on missing/invalid values.
+    """
+    def num(name, required=True, default=None):
+        if name not in source or source.get(name) in (None, ""):
+            if required:
+                raise ValueError(f"Missing required parameter: '{name}'")
+            return default
+        try:
+            return float(source.get(name))
+        except (TypeError, ValueError):
+            raise ValueError(f"Parameter '{name}' must be a number")
+
+    room_length = num("room_length")
+    room_width = num("room_width")
+    pipe_spacing = num("pipe_spacing", required=False, default=DEFAULT_SPACING)
+    return room_length, room_width, pipe_spacing
+
+
+def _layout_from_request():
+    """Build a layout from the current Flask request (JSON body or query)."""
+    if request.method == "POST":
+        source = request.get_json(silent=True)
+        if source is None:
+            # Fall back to form data so curl --data works without a JSON header.
+            source = request.form.to_dict() or {}
+    else:
+        source = request.args.to_dict()
+
+    room_length, room_width, pipe_spacing = _parse_params(source)
+    return compute_layout(room_length, room_width, pipe_spacing)
+
+
+def create_app():
+    """Application factory. Returns a configured Flask app."""
+    app = Flask(__name__)
+
+    @app.get("/health")
+    def health():
+        return jsonify({"status": "ok"})
+
+    @app.route("/api/layout", methods=["GET", "POST"])
+    def api_layout():
+        try:
+            layout = _layout_from_request()
+        except LayoutError as exc:
+            return jsonify({"error": str(exc)}), 422
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+        return jsonify(layout)
+
+    @app.get("/api/layout.svg")
+    def api_layout_svg():
+        try:
+            layout = _layout_from_request()
+        except LayoutError as exc:
+            return jsonify({"error": str(exc)}), 422
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+        try:
+            width_px = int(request.args.get("width", 640))
+        except (TypeError, ValueError):
+            width_px = 640
+        svg = render_svg(layout, width_px=max(200, min(width_px, 2000)))
+        return Response(svg, mimetype="image/svg+xml")
+
+    @app.get("/openapi.json")
+    def openapi():
+        return jsonify(_OPENAPI_SPEC)
+
+    @app.get("/")
+    def index():
+        return Response(_INDEX_HTML, mimetype="text/html")
+
+    return app
+
+
+_OPENAPI_SPEC = {
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Radiant Heating Layout API",
+        "version": "1.0.0",
+        "description": "Compute serpentine radiant heating pipe layouts for rectangular rooms.",
+    },
+    "paths": {
+        "/api/layout": {
+            "get": {
+                "summary": "Compute a layout (query parameters)",
+                "parameters": [
+                    {"name": "room_length", "in": "query", "required": True,
+                     "schema": {"type": "number"}, "description": "Room length in meters."},
+                    {"name": "room_width", "in": "query", "required": True,
+                     "schema": {"type": "number"}, "description": "Room width in meters."},
+                    {"name": "pipe_spacing", "in": "query", "required": False,
+                     "schema": {"type": "number", "default": DEFAULT_SPACING},
+                     "description": "Spacing between pipe runs in meters."},
+                ],
+                "responses": {
+                    "200": {"description": "Computed layout",
+                            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Layout"}}}},
+                    "400": {"description": "Invalid parameters"},
+                    "422": {"description": "Room too small / unprocessable"},
+                },
+            },
+            "post": {
+                "summary": "Compute a layout (JSON body)",
+                "requestBody": {
+                    "required": True,
+                    "content": {"application/json": {"schema": {"$ref": "#/components/schemas/LayoutRequest"}}},
+                },
+                "responses": {
+                    "200": {"description": "Computed layout",
+                            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Layout"}}}},
+                    "400": {"description": "Invalid parameters"},
+                    "422": {"description": "Room too small / unprocessable"},
+                },
+            },
+        },
+        "/api/layout.svg": {
+            "get": {
+                "summary": "Render a layout as SVG",
+                "parameters": [
+                    {"name": "room_length", "in": "query", "required": True, "schema": {"type": "number"}},
+                    {"name": "room_width", "in": "query", "required": True, "schema": {"type": "number"}},
+                    {"name": "pipe_spacing", "in": "query", "required": False, "schema": {"type": "number"}},
+                    {"name": "width", "in": "query", "required": False, "schema": {"type": "integer"}},
+                ],
+                "responses": {"200": {"description": "SVG image",
+                                      "content": {"image/svg+xml": {}}}},
+            }
+        },
+        "/health": {"get": {"summary": "Health check",
+                            "responses": {"200": {"description": "Service healthy"}}}},
+    },
+    "components": {
+        "schemas": {
+            "LayoutRequest": {
+                "type": "object",
+                "required": ["room_length", "room_width"],
+                "properties": {
+                    "room_length": {"type": "number"},
+                    "room_width": {"type": "number"},
+                    "pipe_spacing": {"type": "number", "default": DEFAULT_SPACING},
+                },
+            },
+            "Layout": {
+                "type": "object",
+                "properties": {
+                    "room_length": {"type": "number"},
+                    "room_width": {"type": "number"},
+                    "pipe_spacing": {"type": "number"},
+                    "coordinates": {"type": "array", "items": {
+                        "type": "array", "items": {"type": "number"}}},
+                    "grid": {"type": "object"},
+                    "pipe_length_m": {"type": "number"},
+                    "coverage": {"type": "object"},
+                    "warnings": {"type": "array", "items": {"type": "string"}},
+                },
+            },
+        }
+    },
+}
+
+
+_INDEX_HTML = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Radiant Heating Layout</title>
+<style>
+  body { font-family: system-ui, sans-serif; margin: 0; background: #f4f6f8; color: #1f2933; }
+  header { background: #1f2933; color: #fff; padding: 1rem 1.5rem; }
+  header h1 { margin: 0; font-size: 1.25rem; }
+  main { max-width: 920px; margin: 1.5rem auto; padding: 0 1rem; }
+  form { background: #fff; padding: 1rem 1.25rem; border-radius: 8px; display: flex;
+         gap: 1rem; flex-wrap: wrap; align-items: flex-end; box-shadow: 0 1px 3px rgba(0,0,0,.1); }
+  label { display: flex; flex-direction: column; font-size: .85rem; color: #52606d; gap: .25rem; }
+  input { padding: .45rem .5rem; border: 1px solid #cbd2d9; border-radius: 6px; width: 8rem; }
+  button { padding: .55rem 1.1rem; background: #2f6fd0; color: #fff; border: 0;
+           border-radius: 6px; cursor: pointer; font-size: .95rem; }
+  button:hover { background: #275fb0; }
+  #result { margin-top: 1.25rem; background: #fff; border-radius: 8px; padding: 1rem 1.25rem;
+            box-shadow: 0 1px 3px rgba(0,0,0,.1); }
+  #stats { display: flex; gap: 1.5rem; flex-wrap: wrap; margin-bottom: 1rem; }
+  .stat b { display: block; font-size: 1.3rem; }
+  .stat span { color: #52606d; font-size: .8rem; }
+  svg { max-width: 100%; height: auto; border: 1px solid #e4e7eb; border-radius: 6px; }
+  .err { color: #cf1124; }
+  a { color: #2f6fd0; }
+</style>
+</head>
+<body>
+<header><h1>Radiant Heating Layout Generator</h1></header>
+<main>
+  <form id="f">
+    <label>Room length (m)<input id="room_length" type="number" step="any" value="10"/></label>
+    <label>Room width (m)<input id="room_width" type="number" step="any" value="10"/></label>
+    <label>Pipe spacing (m)<input id="pipe_spacing" type="number" step="any" value="1"/></label>
+    <button type="submit">Generate</button>
+  </form>
+  <div id="result"></div>
+  <p style="color:#7b8794;font-size:.85rem">
+    API: <code>GET /api/layout</code>, <code>POST /api/layout</code>,
+    <code>GET /api/layout.svg</code> &middot;
+    <a href="/openapi.json">OpenAPI spec</a>
+  </p>
+</main>
+<script>
+const f = document.getElementById('f');
+const result = document.getElementById('result');
+async function run(e) {
+  if (e) e.preventDefault();
+  const p = new URLSearchParams({
+    room_length: document.getElementById('room_length').value,
+    room_width: document.getElementById('room_width').value,
+    pipe_spacing: document.getElementById('pipe_spacing').value,
+  });
+  result.innerHTML = 'Computing…';
+  try {
+    const res = await fetch('/api/layout?' + p.toString());
+    const data = await res.json();
+    if (!res.ok) { result.innerHTML = '<p class="err">' + (data.error || 'Error') + '</p>'; return; }
+    const c = data.coverage;
+    const warn = (data.warnings && data.warnings.length)
+      ? '<p class="err">' + data.warnings.join(' ') + '</p>' : '';
+    result.innerHTML =
+      '<div id="stats">' +
+      '<div class="stat"><b>' + data.pipe_length_m + ' m</b><span>Pipe length</span></div>' +
+      '<div class="stat"><b>' + c.coverage_percent + '%</b><span>Coverage</span></div>' +
+      '<div class="stat"><b>' + c.room_area_m2 + ' m²</b><span>Room area</span></div>' +
+      '<div class="stat"><b>' + data.coordinates.length + '</b><span>Path points</span></div>' +
+      '</div>' + warn +
+      '<img alt="layout" src="/api/layout.svg?' + p.toString() + '&width=820"/>';
+  } catch (err) {
+    result.innerHTML = '<p class="err">' + err + '</p>';
+  }
+}
+f.addEventListener('submit', run);
+run();
+</script>
+</body>
+</html>
+"""
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 8000))
+    create_app().run(host="0.0.0.0", port=port, debug=False)

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,120 @@
+"""Unified command-line entrypoint for the radiant heating tools.
+
+This module powers both the pip-installed ``radiant-heat`` console script and
+the standalone PyInstaller executable. It exposes three subcommands:
+
+    radiant-heat compute --length 10 --width 10 --spacing 1   # print JSON layout
+    radiant-heat svg --length 10 --width 10 -o layout.svg      # write an SVG file
+    radiant-heat serve --port 8000                             # run the HTTP API
+
+A separate ``show`` subcommand launches the interactive matplotlib visualizer
+when matplotlib is available.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Support running both as an installed module and as a frozen/script file.
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from radiantheat import compute_layout, LayoutError  # noqa: E402
+from render import render_svg  # noqa: E402
+
+
+def _add_layout_args(parser):
+    parser.add_argument("--length", "-l", type=float, required=True,
+                        help="Room length in meters (Y dimension).")
+    parser.add_argument("--width", "-w", type=float, required=True,
+                        help="Room width in meters (X dimension).")
+    parser.add_argument("--spacing", "-s", type=float, default=0.2,
+                        help="Spacing between pipe runs in meters (default: 0.2).")
+
+
+def _cmd_compute(args):
+    layout = compute_layout(args.length, args.width, args.spacing)
+    print(json.dumps(layout, indent=2))
+    return 0
+
+
+def _cmd_svg(args):
+    layout = compute_layout(args.length, args.width, args.spacing)
+    svg = render_svg(layout, width_px=args.width_px)
+    if args.output and args.output != "-":
+        Path(args.output).write_text(svg, encoding="utf-8")
+        print(f"Wrote {args.output}")
+    else:
+        sys.stdout.write(svg)
+    return 0
+
+
+def _cmd_serve(args):
+    from api import create_app
+    app = create_app()
+    print(f"Serving radiant heating API on http://{args.host}:{args.port}")
+    app.run(host=args.host, port=args.port, debug=args.debug)
+    return 0
+
+
+def _cmd_show(args):
+    try:
+        from radiantheat import radiant_heating_layout
+    except ImportError as exc:  # pragma: no cover - defensive
+        print(f"Visualization unavailable: {exc}", file=sys.stderr)
+        return 1
+    try:
+        import matplotlib  # noqa: F401
+    except ImportError:
+        print("The 'show' command requires matplotlib. Install it with "
+              "'pip install matplotlib', or use 'compute'/'svg' instead.",
+              file=sys.stderr)
+        return 1
+    ok = radiant_heating_layout(args.length, args.width, args.spacing)
+    return 0 if ok else 1
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        prog="radiant-heat",
+        description="Generate and serve radiant heating pipe layouts.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_compute = sub.add_parser("compute", help="Compute a layout and print JSON.")
+    _add_layout_args(p_compute)
+    p_compute.set_defaults(func=_cmd_compute)
+
+    p_svg = sub.add_parser("svg", help="Render a layout as an SVG image.")
+    _add_layout_args(p_svg)
+    p_svg.add_argument("--output", "-o", default="-",
+                       help="Output file path, or '-' for stdout (default).")
+    p_svg.add_argument("--width-px", type=int, default=640,
+                       help="SVG drawing width in pixels (default: 640).")
+    p_svg.set_defaults(func=_cmd_svg)
+
+    p_serve = sub.add_parser("serve", help="Run the HTTP API server.")
+    p_serve.add_argument("--host", default="0.0.0.0", help="Bind host (default: 0.0.0.0).")
+    p_serve.add_argument("--port", "-p", type=int, default=8000, help="Bind port (default: 8000).")
+    p_serve.add_argument("--debug", action="store_true", help="Enable Flask debug mode.")
+    p_serve.set_defaults(func=_cmd_serve)
+
+    p_show = sub.add_parser("show", help="Open the interactive matplotlib visualizer.")
+    _add_layout_args(p_show)
+    p_show.set_defaults(func=_cmd_show)
+
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except LayoutError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/radiantheat.py
+++ b/src/radiantheat.py
@@ -1,9 +1,20 @@
+"""Radiant heating pipe layout generation.
+
+This module contains the *pure* geometry and planning logic for laying out
+radiant heating pipes in a rectangular room using a serpentine pattern. It has
+no hard dependency on matplotlib at import time (the visualization helpers
+import it lazily), so it can be imported by headless services such as the web
+API in :mod:`api`.
+
+Public entry points:
+    - ``validate_inputs``     : validate room/spacing parameters.
+    - ``generate_coordinates``: produce the ordered pipe path for a room.
+    - ``compute_layout``      : high level helper returning a structured dict.
+    - ``radiant_heating_layout``: interactive matplotlib visualization (CLI).
+"""
+
 import numpy as np
-import matplotlib.pyplot as plt
-from matplotlib.animation import FuncAnimation
-from matplotlib.collections import LineCollection
-import matplotlib.colors as mcolors
-import time
+
 
 def create_arc(start_point, end_point, bend_radius, num_points=10):
     """
@@ -13,35 +24,32 @@ def create_arc(start_point, end_point, bend_radius, num_points=10):
     # Get vector between points
     dx = end_point[0] - start_point[0]
     dy = end_point[1] - start_point[1]
-    
+
     # If points are too close for the bend radius, adjust radius
     min_distance = np.sqrt(dx**2 + dy**2)
     if min_distance < 2 * bend_radius:
         bend_radius = min_distance / 2.5
-    
+
     # Calculate center point of the arc
     mid_x = (start_point[0] + end_point[0]) / 2
     mid_y = (start_point[1] + end_point[1]) / 2
-    
-    # Calculate angle between points
-    angle = np.arctan2(dy, dx)
-    
+
     # Create arc points
     if abs(dx) > abs(dy):  # Horizontal to vertical transition
         if dy > 0:  # Going up
-            start_angle = -np.pi/2
+            start_angle = -np.pi / 2
             end_angle = 0 if dx > 0 else -np.pi
         else:  # Going down
-            start_angle = np.pi/2
+            start_angle = np.pi / 2
             end_angle = 0 if dx > 0 else -np.pi
     else:  # Vertical to horizontal transition
         if dx > 0:  # Going right
             start_angle = np.pi if dy > 0 else 0
-            end_angle = np.pi/2 if dy > 0 else -np.pi/2
+            end_angle = np.pi / 2 if dy > 0 else -np.pi / 2
         else:  # Going left
             start_angle = 0 if dy > 0 else -np.pi
-            end_angle = np.pi/2 if dy > 0 else -np.pi/2
-    
+            end_angle = np.pi / 2 if dy > 0 else -np.pi / 2
+
     # Generate arc points
     angles = np.linspace(start_angle, end_angle, num_points)
     arc_points = []
@@ -49,10 +57,11 @@ def create_arc(start_point, end_point, bend_radius, num_points=10):
         x = mid_x + bend_radius * np.cos(angle)
         y = mid_y + bend_radius * np.sin(angle)
         arc_points.append((x, y))
-    
+
     return arc_points
 
-def generate_grid(room_length, room_width, pipe_spacing):
+
+def generate_grid(room_length, room_width, pipe_spacing, verbose=False):
     """
     Generate grid lines based on pipe spacing.
     Returns lists of x and y coordinates for grid lines.
@@ -62,38 +71,40 @@ def generate_grid(room_length, room_width, pipe_spacing):
     x_max = room_width - pipe_spacing
     y_min = pipe_spacing
     y_max = room_length - pipe_spacing
-    
+
     # Calculate number of possible vertical and horizontal lines in the grid
     num_vertical_lines = int((room_width - 2 * pipe_spacing) / pipe_spacing) + 1
     num_horizontal_lines = int((room_length - 2 * pipe_spacing) / pipe_spacing) + 1
-    
+
     # Ensure we have enough space for at least a 2x2 grid
     if num_vertical_lines < 2 or num_horizontal_lines < 2:
         raise ValueError("Room too small for specified spacing")
-    
+
     # Make number of vertical lines even for symmetrical layout
     if num_vertical_lines % 2 != 0:
         num_vertical_lines -= 1  # Decrease to ensure we don't exceed room width
-    
+
     # Calculate actual positions of grid lines with exact spacing
     x_positions = []
     for i in range(num_vertical_lines):
         x = x_min + i * pipe_spacing
         if x <= x_max:  # Only add points within room bounds
             x_positions.append(x)
-    
+
     y_positions = []
     for i in range(num_horizontal_lines):
         y = y_min + i * pipe_spacing
         if y <= y_max:  # Only add points within room bounds
             y_positions.append(y)
-    
-    print(f"\nGrid Information:")
-    print(f"Vertical lines: {len(x_positions)}")
-    print(f"Horizontal lines: {len(y_positions)}")
-    print(f"Grid spacing: {pipe_spacing}m")
-    
+
+    if verbose:
+        print("\nGrid Information:")
+        print(f"Vertical lines: {len(x_positions)}")
+        print(f"Horizontal lines: {len(y_positions)}")
+        print(f"Grid spacing: {pipe_spacing}m")
+
     return x_positions, y_positions, len(x_positions), len(y_positions)
+
 
 def calculate_pipe_length(coords):
     """
@@ -101,22 +112,23 @@ def calculate_pipe_length(coords):
     """
     total_length = 0
     for i in range(1, len(coords)):
-        dx = coords[i][0] - coords[i-1][0]
-        dy = coords[i][1] - coords[i-1][1]
+        dx = coords[i][0] - coords[i - 1][0]
+        dy = coords[i][1] - coords[i - 1][1]
         segment_length = np.sqrt(dx**2 + dy**2)
         total_length += segment_length
     return total_length
 
-def generate_coordinates(room_length, room_width, pipe_spacing):
+
+def generate_coordinates(room_length, room_width, pipe_spacing, verbose=False):
     """
     Step by step pipe layout for a 10x10 room with 1m spacing:
-    
+
     1. Start at (1,1)
     2. Go up vertically to (1,9)
     3. Serpentine pattern until (8,2)
     4. Go down to (8,1)
     5. Return along bottom row to (2,1)
-    
+
     Returns:
     - coords: List of (x,y) coordinates for the pipe path
     - x_positions: List of x coordinates for grid lines
@@ -127,48 +139,46 @@ def generate_coordinates(room_length, room_width, pipe_spacing):
     """
     # Calculate grid points
     x_min = 1.0
-    x_max = room_width - 1.0
     y_min = 1.0
-    y_max = room_length - 1.0
-    
+
     # Calculate number of vertical and horizontal lines
     num_vertical_lines = int((room_width - 2) / pipe_spacing) + 1
     num_horizontal_lines = int((room_length - 2) / pipe_spacing) + 1
-    
+
     # Ensure we have enough space for at least a 2x2 grid
     if num_vertical_lines < 2 or num_horizontal_lines < 2:
         raise ValueError("Room too small for specified spacing")
-    
+
     # Make number of vertical lines even for symmetrical layout
     if num_vertical_lines % 2 != 0:
         num_vertical_lines -= 1
-    
+
     # Generate grid points
     x_positions = [x_min + i * pipe_spacing for i in range(num_vertical_lines)]
     y_positions = [y_min + i * pipe_spacing for i in range(num_horizontal_lines)]
-    
+
     coords = []
-    
+
     # Starting point (bottom left corner)
     start_x = x_positions[0]  # This will be 1.0
     start_y = y_positions[0]  # This will be 1.0
     coords.append((start_x, start_y))
-    
+
     # Initial vertical run - go all the way up
     for y in y_positions[1:]:  # Skip first point since we're already there
         coords.append((start_x, y))
-    
+
     # Serpentine pattern
     for i in range(1, len(x_positions)):
         x = x_positions[i]
-        
+
         if i % 2 == 1:  # Moving down
             coords.append((x, y_positions[-1]))  # Move right at top
-            
+
             # Move down to second row
             for y in reversed(y_positions[1:]):  # Include second row
                 coords.append((x, y))
-            
+
             # If not last column, move right at second row
             if i < len(x_positions) - 1:
                 coords.append((x_positions[i + 1], y_positions[1]))
@@ -176,55 +186,59 @@ def generate_coordinates(room_length, room_width, pipe_spacing):
             # Move up from second row to top
             for y in y_positions[1:]:  # Start from second row
                 coords.append((x, y))
-            
+
             # If not last column, move right at top
             if i < len(x_positions) - 1:
                 coords.append((x_positions[i + 1], y_positions[-1]))
-    
+
     # Now we're at the last vertical line, move down to bottom row
     last_x = x_positions[-1]
     coords.append((last_x, y_positions[0]))
-    
+
     # Return path along bottom row (don't go back to start)
     for x in reversed(x_positions[1:-1]):  # Skip first and last points
         coords.append((x, y_positions[0]))
-    
+
     # Remove any duplicate consecutive points while preserving path order
     deduped_coords = []
     for i in range(len(coords)):
-        if i == 0 or coords[i] != coords[i-1]:
+        if i == 0 or coords[i] != coords[i - 1]:
             deduped_coords.append(coords[i])
     coords = deduped_coords
-    
+
     # Calculate total pipe length
     total_length = calculate_pipe_length(coords)
-    
-    # Calculate coverage area
-    usable_width = room_width - 2
-    usable_length = room_length - 2
-    coverage_area = usable_width * usable_length
-    total_area = room_width * room_length
-    coverage_percent = (coverage_area / total_area) * 100
-    
-    print(f"\nGrid Information:")
-    print(f"Vertical lines: {num_vertical_lines}")
-    print(f"Horizontal lines: {num_horizontal_lines}")
-    print(f"Grid spacing: {pipe_spacing}m")
-    print(f"\nCoverage Information:")
-    print(f"Room area: {total_area:.2f}m²")
-    print(f"Covered area: {coverage_area:.2f}m²")
-    print(f"Coverage percentage: {coverage_percent:.1f}%")
-    print(f"\nPipe Information:")
-    print(f"Total pipe length: {total_length:.2f}m")
-    print(f"Pipe length per m² of room: {(total_length/total_area):.2f}m/m²")
-    print(f"\nPath Information:")
-    print(f"Generated {len(coords)} coordinate points")
-    print(f"Path starts at: ({coords[0][0]:.2f}, {coords[0][1]:.2f})")
-    print(f"Path ends at: ({coords[-1][0]:.2f}, {coords[-1][1]:.2f})")
-    print(f"Coverage: x range [{min(x_positions):.2f}, {max(x_positions):.2f}], "
-          f"y range [{min(y_positions):.2f}, {max(y_positions):.2f}]")
-    
+
+    if verbose:
+        # Calculate coverage area
+        usable_width = room_width - 2
+        usable_length = room_length - 2
+        coverage_area = usable_width * usable_length
+        total_area = room_width * room_length
+        coverage_percent = (coverage_area / total_area) * 100
+
+        print("\nGrid Information:")
+        print(f"Vertical lines: {num_vertical_lines}")
+        print(f"Horizontal lines: {num_horizontal_lines}")
+        print(f"Grid spacing: {pipe_spacing}m")
+        print("\nCoverage Information:")
+        print(f"Room area: {total_area:.2f}m²")
+        print(f"Covered area: {coverage_area:.2f}m²")
+        print(f"Coverage percentage: {coverage_percent:.1f}%")
+        print("\nPipe Information:")
+        print(f"Total pipe length: {total_length:.2f}m")
+        print(f"Pipe length per m² of room: {(total_length/total_area):.2f}m/m²")
+        print("\nPath Information:")
+        print(f"Generated {len(coords)} coordinate points")
+        print(f"Path starts at: ({coords[0][0]:.2f}, {coords[0][1]:.2f})")
+        print(f"Path ends at: ({coords[-1][0]:.2f}, {coords[-1][1]:.2f})")
+        print(
+            f"Coverage: x range [{min(x_positions):.2f}, {max(x_positions):.2f}], "
+            f"y range [{min(y_positions):.2f}, {max(y_positions):.2f}]"
+        )
+
     return coords, x_positions, y_positions, num_vertical_lines, num_horizontal_lines, total_length
+
 
 def validate_inputs(room_length, room_width, pipe_spacing):
     """
@@ -237,17 +251,96 @@ def validate_inputs(room_length, room_width, pipe_spacing):
         return False, "Room width must be greater than 0 meters"
     if pipe_spacing <= 0:
         return False, "Pipe spacing must be greater than 0 meters"
-    
+
     # Check if pipe spacing is too large relative to room dimensions
     min_dimension = min(room_length, room_width)
     if pipe_spacing >= min_dimension / 2:
-        return False, f"Pipe spacing ({pipe_spacing}m) is too large for room dimensions. Must be less than {min_dimension/2:.2f}m"
-    
+        return False, (
+            f"Pipe spacing ({pipe_spacing}m) is too large for room dimensions. "
+            f"Must be less than {min_dimension/2:.2f}m"
+        )
+
     # Check if pipe spacing is unreasonably small
     if pipe_spacing < 0.1:
         return False, "Warning: Pipe spacing less than 0.1m may be impractical. Continue? (y/n): "
-    
+
     return True, ""
+
+
+class LayoutError(ValueError):
+    """Raised when a radiant heating layout cannot be computed for the inputs."""
+
+
+def compute_layout(room_length, room_width, pipe_spacing=0.2):
+    """Compute a radiant heating pipe layout and return structured results.
+
+    This is the headless, service-friendly entry point. It validates the
+    inputs, generates the serpentine pipe path and returns a JSON-serializable
+    dictionary describing the layout, grid and key statistics.
+
+    Args:
+        room_length: Room length in meters (the vertical/Y dimension).
+        room_width: Room width in meters (the horizontal/X dimension).
+        pipe_spacing: Spacing between adjacent pipe runs in meters.
+
+    Returns:
+        dict with keys: ``room_length``, ``room_width``, ``pipe_spacing``,
+        ``coordinates``, ``grid``, ``pipe_length_m``, ``coverage`` and
+        ``warnings``.
+
+    Raises:
+        LayoutError: if the inputs are invalid or the room is too small for
+            the requested spacing.
+    """
+    warnings = []
+    is_valid, message = validate_inputs(room_length, room_width, pipe_spacing)
+    if not is_valid:
+        # A "Continue?" message is only a soft warning about tight spacing; the
+        # geometry is still computable, so surface it rather than failing.
+        if "Continue?" in message:
+            warnings.append("Pipe spacing less than 0.1m may be impractical.")
+        else:
+            raise LayoutError(message)
+
+    try:
+        (
+            coords,
+            x_positions,
+            y_positions,
+            num_vertical_lines,
+            num_horizontal_lines,
+            total_length,
+        ) = generate_coordinates(room_length, room_width, pipe_spacing)
+    except ValueError as exc:
+        raise LayoutError(str(exc)) from exc
+
+    total_area = room_width * room_length
+    usable_width = max(room_width - 2, 0)
+    usable_length = max(room_length - 2, 0)
+    coverage_area = usable_width * usable_length
+    coverage_percent = (coverage_area / total_area) * 100 if total_area else 0.0
+
+    return {
+        "room_length": room_length,
+        "room_width": room_width,
+        "pipe_spacing": pipe_spacing,
+        "coordinates": [[round(x, 4), round(y, 4)] for x, y in coords],
+        "grid": {
+            "x_positions": [round(x, 4) for x in x_positions],
+            "y_positions": [round(y, 4) for y in y_positions],
+            "num_vertical_lines": num_vertical_lines,
+            "num_horizontal_lines": num_horizontal_lines,
+        },
+        "pipe_length_m": round(float(total_length), 4),
+        "coverage": {
+            "room_area_m2": round(total_area, 4),
+            "covered_area_m2": round(coverage_area, 4),
+            "coverage_percent": round(coverage_percent, 2),
+            "pipe_length_per_m2": round(float(total_length) / total_area, 4) if total_area else 0.0,
+        },
+        "warnings": warnings,
+    }
+
 
 def get_valid_input(prompt, input_type=float, min_value=0):
     """Helper function to get valid numerical input from user"""
@@ -258,7 +351,8 @@ def get_valid_input(prompt, input_type=float, min_value=0):
                 return value
             print(f"Please enter a value greater than {min_value}")
         except ValueError:
-            print(f"Please enter a valid number")
+            print("Please enter a valid number")
+
 
 def radiant_heating_layout(room_length, room_width, pipe_spacing=0.2):
     """
@@ -266,6 +360,13 @@ def radiant_heating_layout(room_length, room_width, pipe_spacing=0.2):
     For rooms larger than 600 square meters, shows static layout instead of animation.
     Animation speed is optimized for both small and large rooms.
     """
+    # matplotlib is imported lazily so the rest of this module stays usable in
+    # headless environments (e.g. the web API) where a plotting backend or
+    # display may not be available.
+    import matplotlib.pyplot as plt
+    from matplotlib.animation import FuncAnimation
+    from matplotlib.collections import LineCollection
+
     try:
         # Validate inputs
         is_valid, message = validate_inputs(room_length, room_width, pipe_spacing)
@@ -280,21 +381,23 @@ def radiant_heating_layout(room_length, room_width, pipe_spacing=0.2):
                 return False
 
         print(f"\nCalculating layout for room {room_length}m x {room_width}m with {pipe_spacing}m spacing...")
-        
+
         # Generate coordinates and grid
         try:
-            coords, x_positions, y_positions, num_vertical_lines, num_horizontal_lines, total_length = generate_coordinates(room_length, room_width, pipe_spacing)
+            coords, x_positions, y_positions, num_vertical_lines, num_horizontal_lines, total_length = (
+                generate_coordinates(room_length, room_width, pipe_spacing, verbose=True)
+            )
         except ValueError as e:
             print(f"Error generating coordinates: {str(e)}")
             return False
         except Exception as e:
             print(f"Unexpected error during coordinate generation: {str(e)}")
             return False
-        
+
         if not coords:
             print("Failed to generate valid pipe layout - no coordinates generated")
             return False
-            
+
         if len(coords) < 2:
             print("Failed to generate valid pipe layout - insufficient points for animation")
             return False
@@ -302,7 +405,7 @@ def radiant_heating_layout(room_length, room_width, pipe_spacing=0.2):
         # Calculate room area and determine visualization mode
         room_area = room_length * room_width
         is_large_room = room_area > 600
-        
+
         if is_large_room:
             print(f"\nRoom area ({room_area:.1f}m²) exceeds 600m². Showing static layout.")
         else:
@@ -311,77 +414,76 @@ def radiant_heating_layout(room_length, room_width, pipe_spacing=0.2):
         # Set up the plot with extra space for legend
         plt.ion()  # Turn on interactive mode
         fig = plt.figure(figsize=(12, 8))  # Make figure wider to accommodate legend
-        
+
         # Create main axes with room for legend on right
         ax = fig.add_axes([0.1, 0.1, 0.7, 0.8])  # [left, bottom, width, height]
-        
+
         # Plot room outline
-        room = ax.fill([0, room_width, room_width, 0], [0, 0, room_length, room_length],
-                      alpha=0.1, color='gray', label='Room')
-        
+        ax.fill([0, room_width, room_width, 0], [0, 0, room_length, room_length],
+                alpha=0.1, color='gray', label='Room')
+
         # Plot grid
         for x in x_positions:
             ax.plot([x, x], [0, room_length], 'k:', alpha=0.2)
         for y in y_positions:
             ax.plot([0, room_width], [y, y], 'k:', alpha=0.2)
-        
-        # Plot boundary
-        boundary = ax.plot([pipe_spacing, room_width-pipe_spacing, room_width-pipe_spacing, pipe_spacing, pipe_spacing],
-                         [pipe_spacing, pipe_spacing, room_length-pipe_spacing, room_length-pipe_spacing, pipe_spacing],
-                         'r--', alpha=0.5, label='Pipe Offset Boundary')
 
+        # Plot boundary
+        ax.plot([pipe_spacing, room_width - pipe_spacing, room_width - pipe_spacing, pipe_spacing, pipe_spacing],
+                [pipe_spacing, pipe_spacing, room_length - pipe_spacing, room_length - pipe_spacing, pipe_spacing],
+                'r--', alpha=0.5, label='Pipe Offset Boundary')
+
+        anim = None
         if is_large_room:
-            # For large rooms, plot the entire path at once
-            # Find the transition point from supply to return
-            # This is where we reach the rightmost point before returning
+            # For large rooms, plot the entire path at once. Find the transition
+            # point from supply to return (rightmost point before returning).
             max_x = max(coord[0] for coord in coords)
             transition_idx = next(i for i, coord in enumerate(coords) if coord[0] == max_x)
-            
+
             # Plot supply section in red->yellow gradient
             supply_x = [coord[0] for coord in coords[:transition_idx + 1]]  # Include transition point
             supply_y = [coord[1] for coord in coords[:transition_idx + 1]]
             ax.plot(supply_x, supply_y, 'r-', linewidth=3, label='Supply Line')
-            
+
             # Plot return section in blue gradient
             return_x = [coord[0] for coord in coords[transition_idx:]]  # Include transition point
             return_y = [coord[1] for coord in coords[transition_idx:]]
             ax.plot(return_x, return_y, 'b-', linewidth=3, label='Return Line')
-            
+
             ax.set_title('Radiant Heating Pipe Layout')
         else:
             # For smaller rooms, use animation
-            # Create color gradients for supply and return
             supply_cmap = plt.cm.RdYlBu_r
             return_cmap = plt.cm.RdYlBu
-            
+
             # Initialize empty line collections for installed pipe segments
             installed_segments = LineCollection([], linewidth=3, label='Heating Pipe')
             ax.add_collection(installed_segments)
-            
+
             # Initialize pipe head (installation point) and trail
             pipe_head, = ax.plot([], [], 'ko', markersize=10, label='Installation Point')
             trail, = ax.plot([], [], 'ko', markersize=4, alpha=0.5, label='Installation Trail')
-            
+
             # Add pause frames at start and end
             pause_frames = 20
-            
+
             # Calculate total frames and interval
             total_frames = len(coords) + 2 * pause_frames
-            
+
             # Set minimum and maximum intervals for smooth animation
             min_interval = 5  # milliseconds (fastest)
             max_interval = 30  # milliseconds (slowest)
             target_duration = 10000  # aim for 10 seconds
-            
+
             # Calculate interval to target 10 seconds, but clamp between min and max
             interval = min(max_interval, max(min_interval, target_duration / total_frames))
-            
+
             actual_duration = total_frames * interval / 1000
-            print(f"\nAnimation settings:")
+            print("\nAnimation settings:")
             print(f"Total frames: {total_frames}")
             print(f"Frame interval: {interval:.1f}ms")
             print(f"Total duration: {actual_duration:.1f} seconds")
-            
+
             def update(frame):
                 # Handle pause frames at start and end
                 if frame < pause_frames:
@@ -395,31 +497,31 @@ def radiant_heating_layout(room_length, room_width, pipe_spacing=0.2):
                 if actual_frame > 0:  # Only create segments if we have at least two points
                     segments = []
                     colors = []
-                    for i in range(min(actual_frame, len(coords)-1)):
-                        segments.append([coords[i], coords[i+1]])
+                    for i in range(min(actual_frame, len(coords) - 1)):
+                        segments.append([coords[i], coords[i + 1]])
                         # Color based on supply (first half) or return (second half)
                         if i < len(coords) // 2:
                             color = supply_cmap(i / (len(coords) // 2))
                         else:
                             color = return_cmap((i - len(coords) // 2) / (len(coords) // 2))
                         colors.append(color)
-                    
+
                     # Update installed segments
                     installed_segments.set_segments(segments)
                     installed_segments.set_color(colors)
-                
+
                 # Update pipe head position and trail
                 if actual_frame < len(coords):
                     current_pos = coords[actual_frame]
                     pipe_head.set_data([current_pos[0]], [current_pos[1]])
-                    
+
                     # Create trail effect (last 5 points)
                     trail_length = 5
                     trail_start = max(0, actual_frame - trail_length)
                     trail_x = [coord[0] for coord in coords[trail_start:actual_frame]]
                     trail_y = [coord[1] for coord in coords[trail_start:actual_frame]]
                     trail.set_data(trail_x, trail_y)
-                
+
                 # Update progress in title
                 if actual_frame == 0:
                     ax.set_title('Radiant Heating Pipe Layout (Starting Installation...)')
@@ -428,34 +530,34 @@ def radiant_heating_layout(room_length, room_width, pipe_spacing=0.2):
                 else:
                     progress = (actual_frame / len(coords)) * 100
                     ax.set_title(f'Radiant Heating Pipe Layout ({progress:.1f}% Installed)')
-                
+
                 return installed_segments, pipe_head, trail
-            
+
             # Create animation with pause frames and repeat
-            anim = FuncAnimation(fig, update, frames=total_frames, interval=interval, 
-                               blit=True, repeat=True)
-        
+            anim = FuncAnimation(fig, update, frames=total_frames, interval=interval,
+                                 blit=True, repeat=True)
+
         # Set plot properties
         ax.set_xlabel('Width (m)')
         ax.set_ylabel('Length (m)')
         ax.grid(False)  # Turn off default grid since we're drawing our own
         ax.axis('equal')
-        
+
         # Set axis limits with some padding
         padding = pipe_spacing
         ax.set_xlim(-padding, room_width + padding)
         ax.set_ylim(-padding, room_length + padding)
-        
+
         # Place legend outside the plot on the right
         ax.legend(bbox_to_anchor=(1.15, 0.5), loc='center left')
-        
+
         # Calculate coverage
         usable_width = room_width - 2 * pipe_spacing
         usable_length = room_length - 2 * pipe_spacing
         coverage_area = usable_width * usable_length
         total_area = room_width * room_length
         coverage_percent = (coverage_area / total_area) * 100
-        
+
         # Print statistics
         print("\nRoom Configuration:")
         print(f"Room dimensions: {room_length}m x {room_width}m")
@@ -466,18 +568,22 @@ def radiant_heating_layout(room_length, room_width, pipe_spacing=0.2):
         print(f"Room coverage: {coverage_percent:.1f}%")
         if not is_large_room:
             print("\nStarting visualization...")
-        
+
+        # Keep a reference to the animation so it is not garbage collected.
+        fig._radiant_anim = anim
+
         # Show the plot
         plt.ioff()  # Turn off interactive mode
         plt.show()
-        
+
         return True
-        
+
     except Exception as e:
         print(f"An error occurred: {str(e)}")
         import traceback
         traceback.print_exc()
         return False
+
 
 def main():
     """Main function with error handling and user interaction"""
@@ -485,25 +591,26 @@ def main():
     print("===============================")
     print("This program will create an animated visualization of a radiant heating pipe layout.")
     print("Please enter the following measurements in meters:\n")
-    
+
     try:
         # Get room dimensions with validation
         room_length = get_valid_input("Enter the room length in meters: ")
         room_width = get_valid_input("Enter the room width in meters: ")
         pipe_spacing = get_valid_input("Enter the spacing between pipes in meters (e.g., 0.2): ")
-        
+
         # Create the layout
         success = radiant_heating_layout(room_length, room_width, pipe_spacing)
-        
+
         if not success:
             print("\nFailed to create layout. Please check the input values and try again.")
             return
-            
+
     except KeyboardInterrupt:
         print("\nOperation cancelled by user")
     except Exception as e:
         print(f"\nAn unexpected error occurred: {str(e)}")
         print("Please try again with different values")
+
 
 if __name__ == "__main__":
     main()

--- a/src/render.py
+++ b/src/render.py
@@ -1,0 +1,103 @@
+"""Lightweight SVG rendering of radiant heating layouts.
+
+This module renders the dictionary produced by
+:func:`radiantheat.compute_layout` into an SVG image. It is intentionally
+dependency-free (pure string building) so the web API can return a visual
+representation without pulling in matplotlib or a display backend.
+"""
+
+from xml.sax.saxutils import escape
+
+
+def render_svg(layout, width_px=640, padding_px=40):
+    """Render a layout dict as an SVG document string.
+
+    Args:
+        layout: The dict returned by :func:`radiantheat.compute_layout`.
+        width_px: Target width of the drawing area in pixels. The height is
+            derived from the room aspect ratio.
+        padding_px: Padding around the room, in pixels.
+
+    Returns:
+        A string containing a complete SVG document.
+    """
+    room_w = float(layout["room_width"])
+    room_l = float(layout["room_length"])
+    coords = layout["coordinates"]
+    grid = layout["grid"]
+
+    # Scale so the room fits within width_px (minus padding). Use a uniform
+    # scale for both axes to preserve aspect ratio.
+    draw_w = max(width_px - 2 * padding_px, 1)
+    scale = draw_w / room_w if room_w else 1
+    draw_h = room_l * scale
+
+    svg_w = draw_w + 2 * padding_px
+    svg_h = draw_h + 2 * padding_px
+
+    def tx(x):
+        return padding_px + x * scale
+
+    def ty(y):
+        # Flip Y so that 0 is at the bottom (room coordinates are bottom-left
+        # origin, SVG is top-left origin).
+        return padding_px + (room_l - y) * scale
+
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{svg_w:.1f}" '
+        f'height="{svg_h:.1f}" viewBox="0 0 {svg_w:.1f} {svg_h:.1f}">',
+        '<rect width="100%" height="100%" fill="#ffffff"/>',
+        # Room outline
+        f'<rect x="{tx(0):.2f}" y="{ty(room_l):.2f}" width="{room_w*scale:.2f}" '
+        f'height="{room_l*scale:.2f}" fill="#f4f6f8" stroke="#9aa5b1" '
+        'stroke-width="1.5"/>',
+    ]
+
+    # Grid lines
+    for gx in grid["x_positions"]:
+        parts.append(
+            f'<line x1="{tx(gx):.2f}" y1="{ty(0):.2f}" x2="{tx(gx):.2f}" '
+            f'y2="{ty(room_l):.2f}" stroke="#d9dee3" stroke-width="0.5" '
+            'stroke-dasharray="2,3"/>'
+        )
+    for gy in grid["y_positions"]:
+        parts.append(
+            f'<line x1="{tx(0):.2f}" y1="{ty(gy):.2f}" x2="{tx(room_w):.2f}" '
+            f'y2="{ty(gy):.2f}" stroke="#d9dee3" stroke-width="0.5" '
+            'stroke-dasharray="2,3"/>'
+        )
+
+    # Pipe path. Split into supply (first half) and return (second half) so the
+    # flow direction is visible, mirroring the matplotlib visualization.
+    if len(coords) >= 2:
+        half = len(coords) // 2
+        supply_pts = " ".join(f"{tx(x):.2f},{ty(y):.2f}" for x, y in coords[: half + 1])
+        return_pts = " ".join(f"{tx(x):.2f},{ty(y):.2f}" for x, y in coords[half:])
+        parts.append(
+            f'<polyline points="{supply_pts}" fill="none" stroke="#e8513b" '
+            'stroke-width="3" stroke-linejoin="round" stroke-linecap="round"/>'
+        )
+        parts.append(
+            f'<polyline points="{return_pts}" fill="none" stroke="#2f6fd0" '
+            'stroke-width="3" stroke-linejoin="round" stroke-linecap="round"/>'
+        )
+
+        # Start and end markers
+        sx, sy = coords[0]
+        ex, ey = coords[-1]
+        parts.append(f'<circle cx="{tx(sx):.2f}" cy="{ty(sy):.2f}" r="5" fill="#1a8917"/>')
+        parts.append(f'<circle cx="{tx(ex):.2f}" cy="{ty(ey):.2f}" r="5" fill="#7048e8"/>')
+
+    # Caption
+    caption = (
+        f"{room_w:g}m x {room_l:g}m  |  spacing {layout['pipe_spacing']:g}m  |  "
+        f"pipe {layout['pipe_length_m']:g}m  |  coverage "
+        f"{layout['coverage']['coverage_percent']:g}%"
+    )
+    parts.append(
+        f'<text x="{padding_px}" y="{svg_h - 12:.1f}" font-family="sans-serif" '
+        f'font-size="13" fill="#52606d">{escape(caption)}</text>'
+    )
+
+    parts.append("</svg>")
+    return "\n".join(parts)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,72 @@
+"""Tests for the Flask HTTP API."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent.parent / 'src'))
+
+from api import create_app  # noqa: E402
+
+
+class TestApi(unittest.TestCase):
+    def setUp(self):
+        self.client = create_app().test_client()
+
+    def test_health(self):
+        resp = self.client.get("/health")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json()["status"], "ok")
+
+    def test_index_serves_html(self):
+        resp = self.client.get("/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("text/html", resp.content_type)
+
+    def test_openapi(self):
+        resp = self.client.get("/openapi.json")
+        self.assertEqual(resp.status_code, 200)
+        spec = resp.get_json()
+        self.assertEqual(spec["openapi"], "3.0.3")
+        self.assertIn("/api/layout", spec["paths"])
+
+    def test_layout_get(self):
+        resp = self.client.get("/api/layout?room_length=10&room_width=10&pipe_spacing=1")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertAlmostEqual(data["pipe_length_m"], 71.0, places=2)
+        self.assertEqual(len(data["coordinates"]), 72)
+
+    def test_layout_post_json(self):
+        resp = self.client.post("/api/layout",
+                                json={"room_length": 10, "room_width": 10, "pipe_spacing": 1})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json()["coverage"]["coverage_percent"], 64.0)
+
+    def test_default_spacing(self):
+        resp = self.client.get("/api/layout?room_length=10&room_width=10")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json()["pipe_spacing"], 0.2)
+
+    def test_missing_param_is_400(self):
+        resp = self.client.get("/api/layout?room_length=10")
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("error", resp.get_json())
+
+    def test_non_numeric_is_400(self):
+        resp = self.client.get("/api/layout?room_length=abc&room_width=10")
+        self.assertEqual(resp.status_code, 400)
+
+    def test_room_too_small_is_422(self):
+        resp = self.client.get("/api/layout?room_length=1&room_width=1&pipe_spacing=0.6")
+        self.assertEqual(resp.status_code, 422)
+
+    def test_svg_endpoint(self):
+        resp = self.client.get("/api/layout.svg?room_length=10&room_width=10&pipe_spacing=1")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("image/svg+xml", resp.content_type)
+        self.assertIn(b"<svg", resp.data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,48 @@
+"""Tests for the unified command-line entrypoint."""
+
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent.parent / 'src'))
+
+from cli import main  # noqa: E402
+
+
+class TestCli(unittest.TestCase):
+    def test_compute_prints_json(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = main(["compute", "-l", "10", "-w", "10", "-s", "1"])
+        self.assertEqual(rc, 0)
+        data = json.loads(buf.getvalue())
+        self.assertAlmostEqual(data["pipe_length_m"], 71.0, places=2)
+        self.assertEqual(len(data["coordinates"]), 72)
+
+    def test_svg_to_stdout(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = main(["svg", "-l", "6", "-w", "4", "-s", "1"])
+        self.assertEqual(rc, 0)
+        self.assertIn("<svg", buf.getvalue())
+
+    def test_svg_to_file(self, ):
+        out = Path(__file__).parent / "_cli_tmp.svg"
+        try:
+            rc = main(["svg", "-l", "6", "-w", "4", "-s", "1", "-o", str(out)])
+            self.assertEqual(rc, 0)
+            self.assertTrue(out.exists())
+            self.assertIn("<svg", out.read_text())
+        finally:
+            out.unlink(missing_ok=True)
+
+    def test_invalid_layout_returns_error_code(self):
+        rc = main(["compute", "-l", "1", "-w", "1", "-s", "0.6"])
+        self.assertEqual(rc, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_compute_layout.py
+++ b/tests/test_compute_layout.py
@@ -1,0 +1,55 @@
+"""Tests for the structured compute_layout() entry point and SVG renderer."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent.parent / 'src'))
+
+from radiantheat import compute_layout, LayoutError  # noqa: E402
+from render import render_svg  # noqa: E402
+
+
+class TestComputeLayout(unittest.TestCase):
+    def test_structure_and_values(self):
+        layout = compute_layout(10.0, 10.0, 1.0)
+
+        # Top-level keys
+        for key in ("room_length", "room_width", "pipe_spacing", "coordinates",
+                    "grid", "pipe_length_m", "coverage", "warnings"):
+            self.assertIn(key, layout)
+
+        # Matches the known 10x10 / 1m result used elsewhere in the suite.
+        self.assertEqual(len(layout["coordinates"]), 72)
+        self.assertAlmostEqual(layout["pipe_length_m"], 71.0, places=2)
+        self.assertAlmostEqual(layout["coverage"]["coverage_percent"], 64.0, places=1)
+
+        # Coordinates are JSON-friendly [x, y] pairs.
+        self.assertTrue(all(len(pt) == 2 for pt in layout["coordinates"]))
+        self.assertEqual(layout["warnings"], [])
+
+    def test_invalid_inputs_raise(self):
+        with self.assertRaises(LayoutError):
+            compute_layout(0, 10, 1.0)
+        with self.assertRaises(LayoutError):
+            compute_layout(10, 10, 9.0)  # spacing too large
+
+    def test_room_too_small_raises(self):
+        with self.assertRaises(LayoutError):
+            compute_layout(1.0, 1.0, 0.6)
+
+    def test_small_spacing_warns_but_succeeds(self):
+        layout = compute_layout(10.0, 10.0, 0.05)
+        self.assertTrue(layout["warnings"])
+        self.assertGreater(layout["pipe_length_m"], 0)
+
+    def test_render_svg(self):
+        layout = compute_layout(10.0, 10.0, 1.0)
+        svg = render_svg(layout)
+        self.assertIn("<svg", svg)
+        self.assertIn("polyline", svg)
+        self.assertTrue(svg.strip().endswith("</svg>"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_radiantheat.py
+++ b/tests/test_radiantheat.py
@@ -16,8 +16,10 @@ class TestRadiantHeating(unittest.TestCase):
         self.room_width = 10.0
         self.pipe_spacing = 1.0
         
-        # Load test coordinates from JSON
-        with open('test_coordinates.json', 'r') as f:
+        # Load test coordinates from JSON (resolve relative to this file so the
+        # suite runs from any working directory, including the repo root in CI).
+        fixture = Path(__file__).parent / 'test_coordinates.json'
+        with open(fixture, 'r') as f:
             self.test_data = json.load(f)
         
     def test_validate_inputs(self):


### PR DESCRIPTION
## Summary

Turns the existing single-file script into a layout engine usable as a library, a CLI visualizer, and an HTTP service other applications can call.

### Core refactor (`src/radiantheat.py`)
- matplotlib is now imported lazily inside the visualizer, so the module imports cleanly in headless environments (servers, CI).
- Side-effect `print`s in the geometry functions are gated behind `verbose=` and only used by the CLI.
- New `compute_layout(room_length, room_width, pipe_spacing)` returns a structured, JSON-serializable dict (coordinates, grid, pipe length, coverage, warnings) and raises a typed `LayoutError`.
- Existing public functions (`generate_grid`, `generate_coordinates`, `validate_inputs`) keep their signatures and behavior.

### Web interface (`src/api.py`)
Flask app callable by other services:
- `GET/POST /api/layout` — JSON layout (query params or JSON body); `pipe_spacing` defaults to `0.2`.
- `GET /api/layout.svg` — rendered SVG image.
- `GET /health` — health probe. `GET /openapi.json` — OpenAPI 3.0 spec.
- `GET /` — browser UI.
- Returns `400` for invalid/missing parameters, `422` when the room is too small.

### Rendering (`src/render.py`)
Dependency-free SVG renderer (no matplotlib / display backend needed) used by the API.

### Tests & CI
- Fixed the test fixture path so the suite runs from any working directory.
- Added tests for `compute_layout`, the SVG renderer, and every API endpoint.
- New GitHub Actions workflow runs `pytest` with coverage on Python 3.9–3.12.
- Full suite: **22 passing** locally.

### Docs
README updated with library, API, and CI usage.

## Test plan
- [x] `pytest tests/ -v` → 22 passed
- [x] Headless `import radiantheat` does not load matplotlib
- [x] Live server: `/health`, `/api/layout` (GET+POST), `/api/layout.svg`, and 400/422 error paths verified with curl

https://claude.ai/code/session_01QoFNk5MbFLQd8TfV6Rr6zM

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoFNk5MbFLQd8TfV6Rr6zM)_